### PR TITLE
Ajout des accès avec OpenVPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ Ce que le playbook fait :
 - Sécurisation de MariaDB
 - Sécurisation de PHP
 - Sécurisation de l'OS
+- Installation d'EasyRSA pour sécuriser les accès OpenVPN
+- Installation d'OpenVPN
 
 À faire :
-- Installation d'OpenVPN
-- Sécurisation d'OpenVPN
 - Installation d'Orthanc en réseau local
+- Proposer l'installation d'un module
+- Proposer l'initialisation de données de test avec VilagePeople
 - ?
 
 ## Prérequis
 - Ansible > 2.5
--  Ansible > 2.9 pour le rôle SSH-sec
+- Ansible > 2.9 pour le rôle SSH-sec
 - Avoir configuré correctement l'authentification SSH entre l'ordinateur client et l'ordinateur serveur.
 
 ## Installation 
@@ -41,18 +43,41 @@ ansible-galaxy install -r requirements.yml
 ## Variables
 Les variables des rôles `dev-sec.os-hardening`, `dev-sec.ssh-hardening`, `geerlingguy.firewall`, `jnv.unattended-upgrades`, `geerlingguy.apache`, `geerlingguy.php`, `geerlingguy.mysql`, `dev-sec.mysql-hardening`, sont décrites dans les `README` des projets sur Github.
 
-| Nom                     | Valeurs par défaut                                                       | Description                                                                                |
-| ----                    | ------------------                                                       | ------------                                                                               |
-| timezone                | Europe/Paris                                                             | Mettre à l'heure le serveur                                                                |
-| msehr_package           | ['ghostscript', 'imagemagick', 'pdftk', git', 'curl', 'composer', 'ntp'] | Installer les dépendances de MSEHR                                                         |
-| msehr_base_repo_url     | https://codeload.github.com/MedShake/MedShakeEHR-base/tar.gz/refs/tags/  | Url du dépôt où récupérer l'archive MsEHR                                                   |
-| msehr_base_release      | 7.1.1                                                                    | Version de l'archive à récupérer (sans le préfixe `v`)                                     |
-| msehr_base_checksum     | sha256:8f13f4f3d6e3de6c9d5e3c9de52dd3683909067d0b01c60d6cbf32e530526a2d  | Somme de contrôle à effectuer sur l'archive récupérer                                      |
-| create_self_signed_cert | true                                                                     | Mettre à `false` si vous ne voulez pas créer de certificat auto signé pour le serveur web |
-| countryName             | FR                                                                       | le code de votre pays pour le certificat                                                   |
-| localityName            | Paris                                                                    | Votre ville pour le certificat                                                             |
-| organizationName        | Dr Strange                                                               | Votre raison sociale pour le certificat                                                    |
-| emailAdress             | email@domain.tld                                                         | Votre adresse mail pour le certificat                                                       |
+| Nom                         | Valeurs par défaut                                                       | Description                                                                                                                       |
+| ----                        | ------------------                                                       | ------------                                                                                                                      |
+| timezone                    | Europe/Paris                                                             | Mettre à l'heure le serveur                                                                                                       |
+| msehr_package               | ['ghostscript', 'imagemagick', 'pdftk', git', 'curl', 'composer', 'ntp'] | Installer les dépendances de MSEHR                                                                                                |
+| msehr_base_repo_url         | https://codeload.github.com/MedShake/MedShakeEHR-base/tar.gz/refs/tags/  | Url du dépôt où récupérer l'archive MsEHR                                                                                         |
+| msehr_base_release          | 7.1.1                                                                    | Version de l'archive à récupérer (sans le préfixe `v`)                                                                            |
+| msehr_base_checksum         | sha256:8f13f4f3d6e3de6c9d5e3c9de52dd3683909067d0b01c60d6cbf32e530526a2d  | Somme de contrôle à effectuer sur l'archive récupérer                                                                             |
+| create_self_signed_cert     | true                                                                     | Mettre à `false` si vous ne voulez pas créer de certificat auto signé pour le serveur web                                         |
+| countryName                 | FR                                                                       | le code de votre pays pour le certificat                                                                                          |
+| localityName                | Paris                                                                    | Votre ville pour le certificat                                                                                                    |
+| organizationName            | Dr Strange                                                               | Votre raison sociale pour le certificat                                                                                           |
+| emailAdress                 | email@domain.tld                                                         | Votre adresse mail pour le certificat                                                                                             |
+| easyrsa_alert_renew_service | false                                                                    | Active ou non le rapel par courriel des certificats EasyRSA qui vont expirer (néséssite msmtp mta)                                |
+| easyrsa_ca_pass             | secret                                                                   | Passphrase pour la clé privé de la CA EasyRSA                                                                                     |
+| openvpn_network             | 10.42.42.0                                                               | Réseau ip pour openvpn                                                                                                            |
+| openvpn_netmask             | 255.255.255.0                                                            | Netmask pour le réseau OpenVPN                                                                                                    |
+| clients_medshake            | Liste                                                                    | Liste les client devant accèder à medshake au travers du réseau VPN                                                               |
+| openvpn_remote              | Not set                                                                  | Founir la valeur de `remote` sur les fichier de configuration des clients                                                         |
+| only_vpn_access             | true                                                                     | Si vrais, l'instance MedShake ne sera accèsible que depuis le VPN                                                                 |
+
+## Accès MedShake via OpenVPN
+
+Le rôle met en place un serveur OpenVPN et une [PKI](https://fr.wikipedia.org/wiki/Infrastructure_%C3%A0_cl%C3%A9s_publiques) avec EasyRSA pour sécuriser son accès. Ceci peut être utilisé pour sécuriser les accès à l'instance MedShake à distance. Chaque client devant accéder au serveur dispose de ces propre clé d'accès et de sa propre ip au travers du réseau VPN. Les clients sont configurer dans la variable de configuration du fichier `vars/main.yml` avec la variable `clients_medshake` qui contient une liste ou chaque client est décrit par un nom (`name:`), une passpharse pour protéger la clé privé de son certificat (`pass:`) et l'ip qu'il doit posséder dans le VPN (`ip:`). Voir les exemple dans `vars/main.yml`.
+
+### Configuration OpenVPN pour les client
+
+Pour chaque client une configuration OpenVPN est généré. Les configuration des clients se trouvent sur le serveur dans le dossier `/etc/openvpn/config_for_client/medshake/` dans un fichier `.conf`. Le fichier généré est prêt à l'emploi et contient les clés pour se connecter au serveur. 
+
+### Renouvellement des certificats de clients
+
+Les certificats des clients expire par défaut au bout de 3 ans. Si le playbook est rejoué, le rôle *ansible-role-easyrsa* vas renouveler automatiquement le certificat sauf si le paramètre `renew: false` est ajouté sur l'élément de la liste `clients_medshake`. Le fichier de configuration client OpenVPN pour le client sera mis à jour avec la nouvelle clé et le nouveau certificat.
+
+### Révoquer un certificat
+
+Normalement supprimer un client de la liste `clients_medshake` suffit à lui interdire l'accès au serveur. Il est aussi possible le marquer son certificat comme révoqué en ajoutant `revoked: true` sur un élément de `client_medshake`.
 
 ## Auteur, Contributeurs et Licence
 - Auteur

--- a/playbook.yml
+++ b/playbook.yml
@@ -49,10 +49,11 @@
             openvpn_server:
             - name: "medshake"
               enabled: true
-              remote: "{{ ansible_facts[exposed_iface].ipv4.address }}"
+              remote: "{{ openvpn_remote|default(ansible_facts[exposed_iface].ipv4.address) }}"
               cn: "OpenvpnEHR"
               cli_privkey_dir: "/etc/easyrsa/ca_medshake/pki/private/"
               cli_cert_dir: "/etc/easyrsa/ca_medshake/pki/issued/"
+              port: "{{ openvpn_port|default(1194) }}"
               conf:
                 network: "{{ openvpn_network }}"
                 netmask: "{{ openvpn_netmask }}"
@@ -61,21 +62,27 @@
                 key: "/etc/easyrsa/ca_medshake/pki/private/openvpn.key"
                 crl_file: "/etc/easyrsa/ca_medshake/pki/crl.pem"
               clients: "{{ openvpn_clients_list }}"
+        - name: Set effective domain
+          set_fact:
+            effective_domain: "{{ openvpn_network|regex_replace('([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})\\.[0-9]{1,3}', '\\1.1') if only_vpn_access else domain }}"
+        - name: Add openvpn port to firewall_allowed_udp_ports
+          set_fact:
+            firewall_allowed_udp_ports: "{{ firewall_allowed_udp_ports|default([]) }} + [ {{ openvpn_port|default(1194) }} ]"
 
   roles:
-    - { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'base'] }
-    - { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'base'] }
-    - { role: dev-sec.os-hardening, tags: ['OS-sec', 'security', 'base'] }
-    - { role: dev-sec.ssh-hardening, tags: ['SSH-sec', 'security', 'base'] }
-    - { role: geerlingguy.firewall, tags: ['Firewall', 'security', 'base'] }
-    - { role: jnv.unattended-upgrades, tags: ['AutoUpgrades', 'security', 'base'] }
-    - { role: geerlingguy.mysql, tags: ['MariaDB', 'base', 'minimal'] }
-    - { role: dev-sec.mysql-hardening, tags: ['MariaDB-sec', 'security', 'base'] }
-    - { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
-    - { role: geerlingguy.composer, tags: ['composer', 'base', 'minimal'] } # remove after Debian 10 EOL & add composer to msehrpackage
-    - { role: MedShakeEHR, tags: ['MedShakeEHR', 'base', 'minimal'] }
+    #- { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'base'] }
+    #- { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'base'] }
+    #- { role: dev-sec.os-hardening, tags: ['OS-sec', 'security', 'base'] }
+    #- { role: dev-sec.ssh-hardening, tags: ['SSH-sec', 'security', 'base'] }
+    #- { role: geerlingguy.firewall, tags: ['Firewall', 'security', 'base'] }
+    #- { role: jnv.unattended-upgrades, tags: ['AutoUpgrades', 'security', 'base'] }
+    #- { role: geerlingguy.mysql, tags: ['MariaDB', 'base', 'minimal'] }
+    #- { role: dev-sec.mysql-hardening, tags: ['MariaDB-sec', 'security', 'base'] }
+    #- { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
+    #- { role: geerlingguy.composer, tags: ['composer', 'base', 'minimal'] } # remove after Debian 10 EOL & add composer to msehrpackage
     #- { role: geerlingguy.apache, tags: ['Apache', 'base', 'minimal'] }
-    - { role: Apache-sec, tags: ['Apache', 'security', 'base'] }
+    #- { role: Apache-sec, tags: ['Apache', 'security', 'base'] }
+    - { role: MedShakeEHR, tags: ['MedShakeEHR', 'base', 'minimal'] }
 
   post_tasks:
     - shell: usermod -p "*" {{ user }} # Unlock account after ssh-hardening

--- a/playbook.yml
+++ b/playbook.yml
@@ -70,18 +70,18 @@
             firewall_allowed_udp_ports: "{{ firewall_allowed_udp_ports|default([]) }} + [ {{ openvpn_port|default(1194) }} ]"
 
   roles:
-    #- { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'base'] }
-    #- { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'base'] }
-    #- { role: dev-sec.os-hardening, tags: ['OS-sec', 'security', 'base'] }
-    #- { role: dev-sec.ssh-hardening, tags: ['SSH-sec', 'security', 'base'] }
-    #- { role: geerlingguy.firewall, tags: ['Firewall', 'security', 'base'] }
-    #- { role: jnv.unattended-upgrades, tags: ['AutoUpgrades', 'security', 'base'] }
-    #- { role: geerlingguy.mysql, tags: ['MariaDB', 'base', 'minimal'] }
-    #- { role: dev-sec.mysql-hardening, tags: ['MariaDB-sec', 'security', 'base'] }
-    #- { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
-    #- { role: geerlingguy.composer, tags: ['composer', 'base', 'minimal'] } # remove after Debian 10 EOL & add composer to msehrpackage
-    #- { role: geerlingguy.apache, tags: ['Apache', 'base', 'minimal'] }
-    #- { role: Apache-sec, tags: ['Apache', 'security', 'base'] }
+    - { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'base'] }
+    - { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'base'] }
+    - { role: dev-sec.os-hardening, tags: ['OS-sec', 'security', 'base'] }
+    - { role: dev-sec.ssh-hardening, tags: ['SSH-sec', 'security', 'base'] }
+    - { role: geerlingguy.firewall, tags: ['Firewall', 'security', 'base'] }
+    - { role: jnv.unattended-upgrades, tags: ['AutoUpgrades', 'security', 'base'] }
+    - { role: geerlingguy.mysql, tags: ['MariaDB', 'base', 'minimal'] }
+    - { role: dev-sec.mysql-hardening, tags: ['MariaDB-sec', 'security', 'base'] }
+    - { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
+    - { role: geerlingguy.composer, tags: ['composer', 'base', 'minimal'] } # remove after Debian 10 EOL & add composer to msehrpackage
+    - { role: geerlingguy.apache, tags: ['Apache', 'base', 'minimal'] }
+    - { role: Apache-sec, tags: ['Apache', 'security', 'base'] }
     - { role: MedShakeEHR, tags: ['MedShakeEHR', 'base', 'minimal'] }
 
   post_tasks:

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,10 +1,70 @@
 ---
 - name: Installation
   hosts: all
+  become: yes
   vars_files:
     - vars/main.yml
 
+  pre_tasks:
+    - name: Config Wrapper (help to auto configure some roles variables)
+      block:
+      - name: Configure EasyRSA
+        block:
+        - name: Configure EasyRSA add elements server
+          set_fact:
+            ca_medshake_elements:
+            - name: openvpn
+              type: server
+              cn: "OpenvpnEHR"
+            - name: apache
+              type: server
+              cn: "ApacheEHR"
+        - name: Configure EasyRSA add element clients
+          set_fact:
+            ca_medshake_elements: "{{ ca_medshake_elements }} + [ { 'name': '{{ item.name }}', 'type': 'client', 'pass': '{{ item.pass }}', 'revoked': {{ item.revoked|default(false) }}, 'renew': {{ item.renew|default(true) }} } ]"
+          with_items: "{{ clients_medshake }}"
+        - name: Configure EasyRSA configure CA
+          set_fact:
+            easyrsa_ca_list:
+            - name: "{{ easyrsa_ca_name }}"
+              pass: "{{ easyrsa_ca_pass }}"
+              gen_dh: false
+              conf:
+                req_country: "{{ countryName }}"
+                req_ou: "{{ organizationName }}"
+                req_email: "{{ emailAdress }}"
+                algo: ec
+              elements: "{{ ca_medshake_elements }}"
+      - name: Configure Openvpn
+        block:
+        - name: Configure Openvpn clients (init var)
+          set_fact:
+            openvpn_clients_list: []
+        - name: Configure Openvpn clients
+          set_fact:
+            openvpn_clients_list: "{{ openvpn_clients_list }} + [ { 'name': '{{ item.name }}', 'cc': ['ifconfig-push {{ item.ip }} {{ openvpn_netmask }}'] } ]"
+          with_items: "{{ clients_medshake }}"
+        - name: Configure Openvpn server
+          set_fact:
+            openvpn_server:
+            - name: "medshake"
+              enabled: true
+              remote: "{{ ansible_facts[exposed_iface].ipv4.address }}"
+              cn: "OpenvpnEHR"
+              cli_privkey_dir: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/private/"
+              cli_cert_dir: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/issued/"
+              conf:
+                network: "{{ openvpn_network }}"
+                netmask: "{{ openvpn_netmask }}"
+                ca: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/ca.crt"
+                cert: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/issued/openvpn.crt"
+                key: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/private/openvpn.key"
+                crl_file: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/crl.pem"
+              clients: "{{ openvpn_clients_list }}"
+
   roles:
+    - { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'pki'] }
+    - { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'VPN'] }
     - { role: dev-sec.os-hardening, tags: ['OS-sec', 'security', 'base'] }
     - { role: dev-sec.ssh-hardening, tags: ['SSH-sec', 'security', 'base'] }
     - { role: geerlingguy.firewall, tags: ['Firewall', 'security', 'base'] }
@@ -16,7 +76,7 @@
     - { role: MedShakeEHR, tags: ['MedShakeEHR', 'base', 'minimal'] }
     - { role: geerlingguy.apache, tags: ['Apache', 'base', 'minimal'] }
     - { role: Apache-sec, tags: ['Apache', 'security', 'base'] }
-    #- { role: OpenVPN, tags: ['OpenVPN', 'security', 'VPN']}
+    - { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
 
   post_tasks:
     - shell: usermod -p "*" {{ user }} # Unlock account after ssh-hardening

--- a/playbook.yml
+++ b/playbook.yml
@@ -26,7 +26,7 @@
         - name: Configure EasyRSA configure CA
           set_fact:
             easyrsa_ca_list:
-            - name: "{{ easyrsa_ca_name }}"
+            - name: ca_medshake
               pass: "{{ easyrsa_ca_pass }}"
               gen_dh: false
               conf:
@@ -51,20 +51,20 @@
               enabled: true
               remote: "{{ ansible_facts[exposed_iface].ipv4.address }}"
               cn: "OpenvpnEHR"
-              cli_privkey_dir: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/private/"
-              cli_cert_dir: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/issued/"
+              cli_privkey_dir: "/etc/easyrsa/ca_medshake/pki/private/"
+              cli_cert_dir: "/etc/easyrsa/ca_medshake/pki/issued/"
               conf:
                 network: "{{ openvpn_network }}"
                 netmask: "{{ openvpn_netmask }}"
-                ca: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/ca.crt"
-                cert: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/issued/openvpn.crt"
-                key: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/private/openvpn.key"
-                crl_file: "/etc/easyrsa/{{ easyrsa_ca_name }}/pki/crl.pem"
+                ca: "/etc/easyrsa/ca_medshake/pki/ca.crt"
+                cert: "/etc/easyrsa/ca_medshake/pki/issued/openvpn.crt"
+                key: "/etc/easyrsa/ca_medshake/pki/private/openvpn.key"
+                crl_file: "/etc/easyrsa/ca_medshake/pki/crl.pem"
               clients: "{{ openvpn_clients_list }}"
 
   roles:
-    - { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'pki'] }
-    - { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'VPN'] }
+    - { role: ansible-role-easyrsa, tags: ['EasyRSA', 'security', 'base'] }
+    - { role: ansible-role-openvpn, tags: ['OpenVPN', 'security', 'base'] }
     - { role: dev-sec.os-hardening, tags: ['OS-sec', 'security', 'base'] }
     - { role: dev-sec.ssh-hardening, tags: ['SSH-sec', 'security', 'base'] }
     - { role: geerlingguy.firewall, tags: ['Firewall', 'security', 'base'] }
@@ -74,9 +74,8 @@
     - { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
     - { role: geerlingguy.composer, tags: ['composer', 'base', 'minimal'] } # remove after Debian 10 EOL & add composer to msehrpackage
     - { role: MedShakeEHR, tags: ['MedShakeEHR', 'base', 'minimal'] }
-    - { role: geerlingguy.apache, tags: ['Apache', 'base', 'minimal'] }
+    #- { role: geerlingguy.apache, tags: ['Apache', 'base', 'minimal'] }
     - { role: Apache-sec, tags: ['Apache', 'security', 'base'] }
-    - { role: geerlingguy.php, tags: ['PHP', 'base', 'minimal'] }
 
   post_tasks:
     - shell: usermod -p "*" {{ user }} # Unlock account after ssh-hardening

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
-  - git+https://framagit.org/indelog/ansible-role-easyrsa,v0.0.3
-  - git+https://framagit.org/indelog/ansible-role-openvpn,v0.0.1
+  - git+https://framagit.org/indelog/ansible-role-easyrsa,v0.0.4
+  - git+https://framagit.org/indelog/ansible-role-openvpn,v0.0.2
   - dev-sec.os-hardening
   - dev-sec.ssh-hardening
   - geerlingguy.firewall

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,7 @@
 ---
-roles: 
+roles:
+  - git+https://framagit.org/indelog/ansible-role-easyrsa,v0.0.3
+  #- git+https://framagit.org/indelog/ansible-role-openvpn,v0.0.1
   - dev-sec.os-hardening
   - dev-sec.ssh-hardening
   - geerlingguy.firewall
@@ -9,5 +11,3 @@ roles:
   - geerlingguy.mysql
   - dev-sec.mysql-hardening
   - geerlingguy.composer #remove after debian 10 EOL
-
-

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - git+https://framagit.org/indelog/ansible-role-easyrsa,v0.0.3
-  #- git+https://framagit.org/indelog/ansible-role-openvpn,v0.0.1
+  - git+https://framagit.org/indelog/ansible-role-openvpn,v0.0.1
   - dev-sec.os-hardening
   - dev-sec.ssh-hardening
   - geerlingguy.firewall

--- a/roles/MedShakeEHR/defaults/main.yml
+++ b/roles/MedShakeEHR/defaults/main.yml
@@ -12,3 +12,4 @@ organizationName: Dr Strange
 emailAdress: email@domain.tld
 orthancUser: user
 orthancPswd: orthancPswd
+only_vpn_access: true

--- a/roles/MedShakeEHR/tasks/main.yml
+++ b/roles/MedShakeEHR/tasks/main.yml
@@ -33,16 +33,16 @@
     mode: "u=rwX,go=rX"
     owner: www-data
     group: www-data
-  when: not msehr.stat.exists 
-  
+  when: not msehr.stat.exists
+
 - name: Composer upgrade on /ehr
-  shell: cd "{{ msehrPath }}" && composer upgrade --no-cache   
+  shell: cd "{{ msehrPath }}" && composer upgrade --no-cache
   become: yes
   become_user: www-data
   when: not msehr.stat.exists
 
 - name: Composer upgrade on /ehr/public_html
-  shell: cd "{{ msehrPath }}/public_html" && composer upgrade --no-cache   
+  shell: cd "{{ msehrPath }}/public_html" && composer upgrade --no-cache
   become: yes
   become_user: www-data
   when: not msehr.stat.exists
@@ -55,56 +55,61 @@
     MEDSHAKEEHRPATH: "{{ msehrPath }}"
   when: not msehr.stat.exists
 
-- name: Ensure we have python3 lib for openssl
-  apt:
-    package: python3-openssl
-    state: present
+#
+# No longer required
+# The certificate is no created by ansible-easy-rsa role
+#
 
-- name: Creates SSL directory
-  file:
-    path: "/etc/ssl/{{ domain }}"
-    state: directory
-    recurse: yes
-    owner: root
-    group: root
-    mode: '0755'
-    state: directory
-  when: create_self_signed_cert and  not msehr.stat.exists
+#- name: Ensure we have python3 lib for openssl
+  #apt:
+    #package: python3-openssl
+    #state: present
 
-- name: create private key
-  openssl_privatekey:
-    path: "/etc/ssl/{{ domain }}/{{ domain }}.key"
-    size: 4096
-    state: present
-  when: create_self_signed_cert and  not msehr.stat.exists
+#- name: Creates SSL directory
+  #file:
+    #path: "/etc/ssl/{{ domain }}"
+    #state: directory
+    #recurse: yes
+    #owner: root
+    #group: root
+    #mode: '0755'
+    #state: directory
+  #when: create_self_signed_cert and  not msehr.stat.exists
 
-- name: Generate an OpenSSL Certificate Signing Request with Subject information
-  openssl_csr:
-    path: "/etc/ssl/{{ domain }}/{{ domain }}.csr"
-    privatekey_path: "/etc/ssl/{{ domain }}/{{ domain }}.key"
-    country_name: "{{ countryName }}"
-    locality_name: "{{ localityName }}"
-    organization_name: "{{ organizationName }}"
-    email_address: "{{ emailAdress }}"
-    common_name: "{{ domain }}"
-    state: present
-  when: create_self_signed_cert and  not msehr.stat.exists
+#- name: create private key
+  #openssl_privatekey:
+    #path: "/etc/ssl/{{ domain }}/{{ domain }}.key"
+    #size: 4096
+    #state: present
+  #when: create_self_signed_cert and  not msehr.stat.exists
 
-- name: Generate a Self Signed OpenSSL certificate
-  openssl_certificate:
-    path: "/etc/ssl/{{ domain }}/{{ domain }}.pem"
-    privatekey_path: "/etc/ssl/{{ domain }}/{{ domain }}.key"
-    csr_path: "/etc/ssl/{{ domain }}/{{ domain }}.csr"
-    provider: selfsigned
-    valid_in: "315360000"
-    state: present
-  when: create_self_signed_cert and  not msehr.stat.exists
+#- name: Generate an OpenSSL Certificate Signing Request with Subject information
+  #openssl_csr:
+    #path: "/etc/ssl/{{ domain }}/{{ domain }}.csr"
+    #privatekey_path: "/etc/ssl/{{ domain }}/{{ domain }}.key"
+    #country_name: "{{ countryName }}"
+    #locality_name: "{{ localityName }}"
+    #organization_name: "{{ organizationName }}"
+    #email_address: "{{ emailAdress }}"
+    #common_name: "{{ domain }}"
+    #state: present
+  #when: create_self_signed_cert and  not msehr.stat.exists
 
-- name: Clean the Certificate Signing Request
-  file:
-    path: "/etc/ssl/{{ domain }}/{{ domain }}.csr"
-    state: absent
-  when: create_self_signed_cert and  not msehr.stat.exists
+#- name: Generate a Self Signed OpenSSL certificate
+  #openssl_certificate:
+    #path: "/etc/ssl/{{ domain }}/{{ domain }}.pem"
+    #privatekey_path: "/etc/ssl/{{ domain }}/{{ domain }}.key"
+    #csr_path: "/etc/ssl/{{ domain }}/{{ domain }}.csr"
+    #provider: selfsigned
+    #valid_in: "315360000"
+    #state: present
+  #when: create_self_signed_cert and  not msehr.stat.exists
+
+#- name: Clean the Certificate Signing Request
+  #file:
+    #path: "/etc/ssl/{{ domain }}/{{ domain }}.csr"
+    #state: absent
+  #when: create_self_signed_cert and  not msehr.stat.exists
 
 - name: Gather package facts
   package_facts:

--- a/roles/MedShakeEHR/tasks/main.yml
+++ b/roles/MedShakeEHR/tasks/main.yml
@@ -48,7 +48,7 @@
   when: not msehr.stat.exists
 
 - name: Execute MedShakeEHR cli installation script
-  shell: "/usr/bin/php {{ msehrPath }}/public_html/install.php -s localhost -N -d {{ mysql_databases[0]['name'] }} -u {{ mysql_users[0]['name'] }} -p \"{{ mysql_users[0]['password'] }}\" -r https -D {{ domain }}"
+  shell: "/usr/bin/php {{ msehrPath }}/public_html/install.php -s localhost -N -d {{ mysql_databases[0]['name'] }} -u {{ mysql_users[0]['name'] }} -p \"{{ mysql_users[0]['password'] }}\" -r https -D \"{{ effective_domain }}\""
   become: yes
   become_user: www-data
   environment:
@@ -121,7 +121,7 @@
     dest: "/etc/orthanc/orthanc.json"
     owner: root
     group: root
-    mode: 0644
+    mode: "0644"
   when: "'orthanc' in ansible_facts.packages"
 
 - name: Creating MEDSHAKEEHRPATH file
@@ -130,3 +130,33 @@
     content: |
       {{ msehrPath }}
   when: not msehr.stat.exists
+
+- name: Config apache for MedShakeEHR
+  block:
+  - name: Log dir for MedShake (www-data must can read this file or directory)
+    file:
+      path: /var/log/medshake/
+      mode: "0770"
+      owner: www-data
+      group: www-data
+      state: directory
+  - name: Log dir for MedShake (www-data must can read this file or directory)
+    copy:
+      src: logrotate-medshake
+      dest: /etc/logrotate.d/medshake
+      mode: "0644"
+      owner: root
+      group: root
+  - name: Create apache config for MedShakeEHR
+    template:
+      src: apache-medshake.conf.j2
+      dest: /etc/apache2/sites-available/medshake.conf
+      owner: root
+      group: root
+      mode: "0644"
+    notify: restart apache
+  - name: Ensure conf apache for MedShakeEHR is enabled
+    command: /usr/sbin/a2ensite medshake.conf
+    args:
+      creates: /etc/apache2/sites-enabled/medshake.conf
+

--- a/roles/MedShakeEHR/tasks/main.yml
+++ b/roles/MedShakeEHR/tasks/main.yml
@@ -131,6 +131,11 @@
       {{ msehrPath }}
   when: not msehr.stat.exists
 
+- name: Ensure install script is absent
+  file:
+    path: "{{ msehrPath }}/public_html/install.php"
+    state: absent
+
 - name: Config apache for MedShakeEHR
   block:
   - name: Log dir for MedShake (www-data must can read this file or directory)

--- a/roles/MedShakeEHR/templates/apache-medshake.conf.j2
+++ b/roles/MedShakeEHR/templates/apache-medshake.conf.j2
@@ -1,0 +1,45 @@
+<VirtualHost {% if only_vpn_access %}{{ effective_domain }}{% else %}*{% endif %}:80>
+    ServerAdmin	{{ emailAdress }}
+{% if only_vpn_access %}
+    ServerName {{ domain }}
+{% endif %}
+    RedirectMatch permanent ^(.*)/$ https://{{ effective_domain }}/$1
+</VirtualHost>
+
+<VirtualHost {% if only_vpn_access %}{{ effective_domain }}{% else %}*{% endif %}:443>
+
+    ServerAdmin	{{ emailAdress }}
+{% if not only_vpn_access %}
+    ServerName  {{ domain }}
+{% endif %}
+
+    SSLEngine On
+    SSLCertificateFile /etc/easyrsa/ca_medshake/pki/issued/apache.crt
+    SSLCertificateKeyFile /etc/easyrsa/ca_medshake/pki/private/apache.key
+
+    DocumentRoot {{ msehrPath }}/public_html/
+    DirectoryIndex index.php
+
+    CookieName apacheLogUserID
+    # TODO: It not work with an ip (for vpn direct access)
+    CookieDomain .{{ effective_domain }}
+    Define MEDSHAKEEHRLOGFILE /var/log/medshake/access.log
+    SetEnv MEDSHAKEEHRLOGFILE ${MEDSHAKEEHRLOGFILE}
+    LogFormat "{% raw %}%{%Y-%m-%d %H:%M:%S}t{% endraw %} %{c}a %r %{Cookie}n" usertrack
+    SetEnvIf Request_URI "\.png$|\.gif$|\.jpg$|\.svg$|\.js$|\.css$|\.map$|\.ico$|\.woff2" do_not_log
+    CustomLog ${MEDSHAKEEHRLOGFILE} usertrack env=!do_not_log
+    
+    RewriteEngine On
+    
+    <Directory {{ msehrPath }}/public_html/>
+        SetEnv MEDSHAKEEHRPATH {{ msehrPath }}
+        Require all granted
+        Options FollowSymLinks
+        AllowOverride all
+    </Directory>
+
+     <FilesMatch "composer.(json|lock)">
+         Require all denied
+     </FilesMatch>
+
+</VirtualHost>

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -198,6 +198,7 @@ mysql_users:
 easyrsa_alert_renew_service: false
 # Name of the CA for MedShake
 # Pass for CA private key
+# /!\ REPLACE THIS WITH YOUR OWN PASSWORD
 easyrsa_ca_pass: "secret"
 
 #
@@ -218,13 +219,16 @@ clients_medshake:
   - name: drstrange
     pass: 'secret'
     ip: '10.42.42.10'
+#   renew: false            # disable client certificate renew when re-play the playbook (occurs only when certificate is expired)
+#   revoked: true           # revoke the EasyRSA certificate for the client (avoid it to connect to the VPN)
   - name: drjekyll
     pass: 'secret'
     ip: '10.42.42.11'
 # This is the iface where the vpn server is listning
-# (used to get his ip)
+# (used to get his ip quickly when test with Vagrant, for production usage use
+# openvpn_remote)
 exposed_iface: eth0
-# If is set use this remote adresse reather than ip of exposed_iface
+# Set "remote" for config generated for OpenVPN clients
 #openvpn_remote: xxx.xxx.xxx.xxx
 
 # If is true, MedShakeEHR will only accessible by the VPN network

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ domain: msehr.local
 timezone: "Europe/Paris"
 msehrPath: "/home/ehr"
 
-msehr_package: ['acl','curl','ghostscript','git','grub','imagemagick','ntp','pdftk','wget']
+msehr_package: ['acl','curl','ghostscript','git','grub','imagemagick','ntp','pdftk','wget', 'dcmtk']
 
 msehr_base_repo_url: "https://codeload.github.com/MedShake/MedShakeEHR-base/tar.gz/refs/tags/"
 # MSEHR version to get
@@ -75,6 +75,9 @@ apache_create_vhosts: false
 # Set this to `true` to remove that default.
 apache_remove_default_vhost: true
 
+#
+# Apache config for MedShakeEHR is now managed by MedShakeEHR role
+# (need custom template to restrict acces for VPN only)
 #apache_vhosts:
   ## Additional properties:
   ## 'serveradmin, serveralias, allow_override, options, extra_parameters'.
@@ -136,7 +139,7 @@ php_enable_apc: false
 # Any and all changes to /etc/php.ini will be your responsibility.
 php_use_managed_ini: true
 
-php_max_input_vars: "10000"
+php_max_input_vars: "20000"
 php_upload_max_filesize: "64M"
 php_post_max_size: "32M"
 php_date_timezone: "Europe/Paris"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -55,8 +55,7 @@ firewall_allowed_tcp_ports:
   - "22"
   - "80"
   - "443"
-  - "1194"
-
+  
 # jnv.unattended-upgrades Vars
 unattended_remove_unused_dependencies: true
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -87,8 +87,8 @@ apache_vhosts_ssl:
 #  'serveradmin, serveralias, allow_override, options, extra_parameters'.
   - servername: "msehr.local"
     documentroot: "/home/ehr/public_html/"
-    certificate_file: "/etc/ssl/msehr.local/msehr.local.pem"
-    certificate_key_file: "/etc/ssl/msehr.local/msehr.local.key"
+    certificate_file: "/etc/easyrsa/ca_medshake/pki/issued/apache.crt"
+    certificate_key_file: "/etc/easyrsa/ca_medshake/pki/private/apache.key"
 #   # Optional.
 #   certificate_chain_file: "/path/to/certificate_chain.crt"
 
@@ -194,7 +194,6 @@ mysql_users:
 # send mail (with a tool like msmtp-mta).
 easyrsa_alert_renew_service: false
 # Name of the CA for MedShake
-easyrsa_ca_name: ca_medshake
 # Pass for CA private key
 easyrsa_ca_pass: "secret"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -184,3 +184,41 @@ mysql_users:
     # /!\ REPLACE THIS WITH YOUR OWN PASSWORD
     password: secret
     priv: "medshakeehr.*:ALL"
+
+#
+# EasyRsa Configuration
+#
+
+# This enable the service to send warn mail when a certificate will expire.
+# If you enable this ou will ensure your system is able to send email whith
+# send mail (with a tool like msmtp-mta).
+easyrsa_alert_renew_service: false
+# Name of the CA for MedShake
+easyrsa_ca_name: ca_medshake
+# Pass for CA private key
+easyrsa_ca_pass: "secret"
+
+#
+# Openvpn configuration
+#
+
+# VPN network
+openvpn_network: "10.42.42.0"
+# VPN netmask
+openvpn_netmask: "255.255.255.0"
+# List of VPN client
+# For each client :
+# - set a name (only alpha numeric characters whith no space)
+# - set a pass (for the private key of the certficate)
+# - set a ip (for ip of client in the vpn, must be in vpn network)
+# - if the client certficate is revoked add 'revoked: true'
+clients_medshake:
+  - name: drstrange
+    pass: 'secret'
+    ip: '10.42.42.10'
+  - name: drjekyll
+    pass: 'secret'
+    ip: '10.42.42.11'
+# This is the iface where the vpn server is listning
+# (used to get his ip)
+exposed_iface: eth0

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -204,7 +204,8 @@ easyrsa_ca_pass: "secret"
 #
 # Openvpn configuration
 #
-
+# IP of OpenVPN Server, configure before play the role for generate good config file
+openvpn_remote: 
 # VPN network
 openvpn_network: "10.42.42.0"
 # VPN netmask

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ domain: msehr.local
 timezone: "Europe/Paris"
 msehrPath: "/home/ehr"
 
-msehr_package: ['acl','curl','ghostscript','git','grub','imagemagick','ntp','pdftk','wget', 'dcmtk']
+msehr_package: ['acl','curl','dcmtk','ghostscript','git','grub','imagemagick','ntp','pdftk','wget']
 
 msehr_base_repo_url: "https://codeload.github.com/MedShake/MedShakeEHR-base/tar.gz/refs/tags/"
 # MSEHR version to get
@@ -55,6 +55,7 @@ firewall_allowed_tcp_ports:
   - "22"
   - "80"
   - "443"
+  - "1194"
 
 # jnv.unattended-upgrades Vars
 unattended_remove_unused_dependencies: true
@@ -193,7 +194,7 @@ mysql_users:
 #
 
 # This enable the service to send warn mail when a certificate will expire.
-# If you enable this ou will ensure your system is able to send email whith
+# If you enable this you will ensure your system is able to send email with
 # send mail (with a tool like msmtp-mta).
 easyrsa_alert_renew_service: false
 # Name of the CA for MedShake
@@ -211,10 +212,10 @@ openvpn_network: "10.42.42.0"
 openvpn_netmask: "255.255.255.0"
 # List of VPN client
 # For each client :
-# - set a name (only alpha numeric characters whith no space)
-# - set a pass (for the private key of the certficate)
+# - set a name (only alpha numeric characters with no space)
+# - set a pass (for the private key of the certificate)
 # - set a ip (for ip of client in the vpn, must be in vpn network)
-# - if the client certficate is revoked add 'revoked: true'
+# - if the client certificate is revoked add 'revoked: true'
 clients_medshake:
   - name: drstrange
     pass: 'secret'
@@ -224,7 +225,7 @@ clients_medshake:
   - name: drjekyll
     pass: 'secret'
     ip: '10.42.42.11'
-# This is the iface where the vpn server is listning
+# This is the iface where the vpn server is listening
 # (used to get his ip quickly when test with Vagrant, for production usage use
 # openvpn_remote)
 exposed_iface: eth0
@@ -233,6 +234,6 @@ exposed_iface: eth0
 
 # If is true, MedShakeEHR will only accessible by the VPN network
 # Is greatly recommended to keep this at 'true' if the MedShake instance
-# is accèsible by sevral client (not only by the poste which host the
+# is accessible by several client (not only by the post which host the
 # instance).
 only_vpn_access: true

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -56,7 +56,6 @@ firewall_allowed_tcp_ports:
   - "80"
   - "443"
 
-
 # jnv.unattended-upgrades Vars
 unattended_remove_unused_dependencies: true
 
@@ -68,29 +67,29 @@ apache_listen_ip: "*"
 apache_listen_port: 80
 apache_listen_port_ssl: 443
 
-apache_create_vhosts: true
-apache_vhosts_filename: "vhosts.conf"
-apache_vhosts_template: "vhosts.conf.j2"
+apache_create_vhosts: false
+#apache_vhosts_filename: "vhosts.conf"
+#apache_vhosts_template: "vhosts.conf.j2"
 
 # On Debian/Ubuntu, a default virtualhost is included in Apache's configuration.
 # Set this to `true` to remove that default.
 apache_remove_default_vhost: true
 
-apache_vhosts:
-  # Additional properties:
-  # 'serveradmin, serveralias, allow_override, options, extra_parameters'.
-  - servername: "msehr.local"
-    documentroot: "/home/ehr/public_html/"
+#apache_vhosts:
+  ## Additional properties:
+  ## 'serveradmin, serveralias, allow_override, options, extra_parameters'.
+  #- servername: "msehr.local"
+    #documentroot: "/home/ehr/public_html/"
 
-apache_vhosts_ssl:
+#apache_vhosts_ssl:
 #  Additional properties:
 #  'serveradmin, serveralias, allow_override, options, extra_parameters'.
-  - servername: "msehr.local"
-    documentroot: "/home/ehr/public_html/"
-    certificate_file: "/etc/easyrsa/ca_medshake/pki/issued/apache.crt"
-    certificate_key_file: "/etc/easyrsa/ca_medshake/pki/private/apache.key"
-#   # Optional.
-#   certificate_chain_file: "/path/to/certificate_chain.crt"
+  #- servername: "msehr.local"
+    #documentroot: "/home/ehr/public_html/"
+    #certificate_file: "/etc/easyrsa/ca_medshake/pki/issued/apache.crt"
+    #certificate_key_file: "/etc/easyrsa/ca_medshake/pki/private/apache.key"
+##   # Optional.
+##   certificate_chain_file: "/path/to/certificate_chain.crt"
 
 apache_ignore_missing_ssl_certificate: true
 
@@ -99,6 +98,7 @@ apache_mods_enabled:
   - rewrite.load
   - headers.load
   - ssl.load
+  - usertrack.load
 apache_mods_disabled: []
 
 
@@ -221,3 +221,11 @@ clients_medshake:
 # This is the iface where the vpn server is listning
 # (used to get his ip)
 exposed_iface: eth0
+# If is set use this remote adresse reather than ip of exposed_iface
+#openvpn_remote: xxx.xxx.xxx.xxx
+
+# If is true, MedShakeEHR will only accessible by the VPN network
+# Is greatly recommended to keep this at 'true' if the MedShake instance
+# is accèsible by sevral client (not only by the poste which host the
+# instance).
+only_vpn_access: true


### PR DESCRIPTION
J'ai terminé une base pour que le rôle installe et paramètre un serveur OpenVPN pour sécuriser l'accès MedShake (c'est perfectible mais c'est totalement fonctionnel dans l'état).

Basiquement il utilise deux rôle que j'ai écrit pour l'occasion : 

* <https://framagit.org/indelog/ansible-role-easyrsa> : qui est chargé de crée et géré l'autorité de certification pour les certificats des clients du VPN
* <https://framagit.org/indelog/ansible-role-openvpn> : qui met en place le serveur VPN

*(J'ai fait des rôle sur mesure pour ça car les rôle pré existant ne possédaient pas fonctionnalité que je voulais comme la possibilité d'alerter par courriel quant un certificat va expirer ou la génération automatique de configuration pour les client pour OpenVPN et d'autres truc...).*

Comme mes rôle possède beaucoup de variable de configuration qui ne sont pas nécessaire dans le cadre du rôle MedShake j'ai fait un petit *wrapper* (en pré-task du playbook) pour prendre en charge le paramétrage des rôle OpenVPN/EasyRSA. Ainsi la configuration pour un client se limite seulement à l'ajout d'un élément dans la variable de configuration `clients_medshake`, par exemple si j'ai un client `drstrange` je vais avoir quelques chose comme ceci : 

```yaml
clients_medshake:
  - name: drstrange
    pass: 'secret'
    ip: '10.42.42.10'
````

La directive "pass" permet de protéger la clé privé par  mot de passe. Tout les client doivent se voire attribuer leur propre ip au sein du VPN (ce qui permet de contrôler les accès de manière encore plus fine).

Le rôle OpenVPN génère une configuration prête à l'emploie (qui contient toutes les clé pour se connecter au serveur), ainsi il est juste nécessaire de fournir un seul fichier au client. Les configuration pour les client VPN sont sur le serveur dans : `/etc/openvpn/config_for_client/medshake/`.

Avec l'utilisation d'OpenVPN on peut sécuriser l'accès à distance mais aussi sur le réseau local. En plaçant le paramètre de configuration `only_vpn_access` à `true` seul les clients connecté au VPN pourrons accéder à l'instance MedShake même sur le réseau local (ce accroît la sécurité de l'accès à l'instance).

Un accès peut être révoqué quant on veut en ajoutant `revoked: true` au paramètre du client.

Entres deux je j'ai commencer à m’intéresser à la solution de VPN [Wireguard](https://www.wireguard.com/) qui pourrais avantageusement remplacer OpenVPN (Wireguard propose une configuration bien plus simple et sans nécessiter de PKI).  A voire peut pour proposer la solution en alternative au choix à OpenVPN.